### PR TITLE
Resolve sourcecode dependencies

### DIFF
--- a/tasks/typescript.js
+++ b/tasks/typescript.js
@@ -136,12 +136,16 @@ module.exports = function (grunt) {
 
         var resolver = new ts.CodeResolver(env);
         var resolutionDispatcher = {
+            sources = {},
             postResolutionError : function (errorFile, errorMessage) {
                  grunt.fail.warn(errorFile + " : " + errorMessage);
             },
             postResolution : function (path, code) {
-                compiler.addSourceUnit(code, path);
-                grunt.verbose.writeln("Compiling " + path.cyan);
+                if (!sources[path]) {
+                    compiler.addSourceUnit(code, path);
+                    grunt.verbose.writeln("Compiling " + path.cyan);
+                    sources[path] = true;
+                }
             }
         };
         srces.forEach(function (src) {


### PR DESCRIPTION
Currently, grunt-typescript doesn't resolve dependencies declared in sources. For example, like:

```
/// <reference path="Libs/node.d.ts" />
```

This patch makes use of `TypeScript.CodeResolver` to solve this problem.
