### PR TITLE
Don't show result when output file is null 

### DIFF
--- a/tasks/typescript.js
+++ b/tasks/typescript.js
@@ -252,7 +252,7 @@ module.exports = function (grunt) {
         var resultMessage = "js: " + result.js.length + " files, map: " +
             result.m.length + " files, declaration: " +
             result.d.length + " files";
-        if (outputOne) {
+        if (outputOne && result.js.length > 0) {
             grunt.log.writeln("File " + (result.js[0]).cyan + " created.");
             grunt.log.writeln(resultMessage);
         } else {


### PR DESCRIPTION
出力ファイルが空の時、undefined#cyanに触れて落ちてしまう
普通あまり問題にならないと思いますが、ボイラープレート的な空ディレクトリを作ったときにエラーで落ちていて気になりました
