### PR TITLE
On compile errors, cleanly fail the task, instead of aborting grunt altogether

### DIFF
--- a/tasks/typescript.js
+++ b/tasks/typescript.js
@@ -138,7 +138,7 @@ module.exports = function (grunt) {
 
             compile(files, dest, grunt.util._.clone(options), extension);
             if (grunt.task.current.errorCount) {
-                grunt.fail.warn(grunt.task.current.errorCount + " error(s)");
+                return false;
             }
         });
     });


### PR DESCRIPTION
Hello K-maru!

According the grunt's API docs (http://gruntjs.com/api/grunt.fail),
grunt.fail is used for situations when "something explodes (or is about
to explode)". Compilation errors are a normal failure scenario for a
compile task, rather than an exception case.

The practical reason for this change is that I run grunt-typescript on a
watch, as part of a large multi-task. In earlier versions it would
output error messages as expected, but after 13b07368828 the use of
grunt.fail in this task causes grunt to abort, killing the watch and
all.

（中途半端な日本語を許してください）

GruntのAPIの説明（http://gruntjs.com/api/grunt.fail ）によると、grunt.failは非常なときにだけ使うためのAPIのようです。コンパイルしてるタスクにとっては、コンパイルエラーは非常ではなく、日常のことでしょう。だからgrunt.failを使うより、普通のタスクの失敗終了のreturn falseの方が相応しいのはずです。

私はgrunt-typescriptを大きなgruntのwatchタスクの中で使っています。 13b07368828 の前は、コンパイルエラーの時、画面にエラーのお知らせが出て、watchのタスクは次のファイルの変更を待ち続けていました。 13b07368828 の後は、gruntは全体的落とされて、watchのタスクを手動的に実行しなおさなきゃいけなくなりました。

-a
