### PR TITLE
Fix: issue #23

### DIFF
--- a/tasks/typescript.js
+++ b/tasks/typescript.js
@@ -47,7 +47,7 @@ module.exports = function (grunt) {
                             if (!outputOne) {
                                 var g = path.join(currentPath, basePath);
                                 writeFile = writeFile.substr(g.length);
-                                writeFile = path.join(currentPath, destPath, writeFile);
+                                writeFile = path.join(currentPath, destPath ? destPath.toString() : '', writeFile);
                             }
 
                             grunt.file.write(writeFile, source);


### PR DESCRIPTION
Hello,
I made a very simple fix to solve issue #23.

Task throws "Arguments to path.join must be strings" error on windows
