### PR TITLE
Fix: issue #25

### DIFF
--- a/tasks/typescript.js
+++ b/tasks/typescript.js
@@ -9,7 +9,6 @@ module.exports = function (grunt) {
     var path = require('path'),
         fs = require('fs'),
         vm = require('vm'),
-        errorBuffer = "",
         gruntIO = function (currentPath, destPath, basePath, compSetting, outputOne) {
             var createdFiles = [];
             basePath = basePath || ".";
@@ -91,11 +90,9 @@ module.exports = function (grunt) {
                 },
                 stderr:{
                     Write:function (str) {
-                        errorBuffer += str;
                         grunt.log.error(str);
                     },
                     WriteLine:function (str) {
-                        errorBuffer += str + "\n";
                         grunt.log.error(str);
                     },
                     Close:function () {
@@ -146,7 +143,6 @@ module.exports = function (grunt) {
         });
 
         if (grunt.task.current.errorCount) {
-            grunt.fail.warn(errorBuffer);
             return false;
         }
     });


### PR DESCRIPTION
Hello,
I made a simple fix to solve issue #25.

All error now saves to the "error" buffer. if an error occurs, "error" buffer is displayed in "grunt.fail.warn".
