### PR TITLE
fix task failure when typescript looks for files that may be missing

### DIFF
--- a/tasks/typescript.js
+++ b/tasks/typescript.js
@@ -20,12 +20,11 @@ module.exports = function (grunt) {
 
                 resolvePath:path.resolve,
                 readFile:function (file){
-                    var content = grunt.file.read(file);
+                    var content = fs.readFileSync(file, 'utf8');
                     // strip UTF BOM
                     if(content.charCodeAt(0) === 0xFEFF){
                         content = content.slice(1);
                     }
-
                     return content;
                 },
                 dirName:path.dirname,


### PR DESCRIPTION
typescript seems to look for available files by trying to read them, this causes
problems as if the grunt.file.read fails it will fail the task.
