### PR TITLE
Cache the ts bin path (and typescript.js module) after loading it once

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,11 +49,17 @@ module.exports = function(grunt: IGrunt){
             }
         };
 
+    // Used to avoid reloading the "typescript.js" file each time a compilation task processed.  Saves a
+    // considerable amount of time when there are multiple tasks.
+    var cacheBinPath:string;
+
     grunt.registerMultiTask('typescript', 'Compile TypeScript files', function () {
         var self: grunt.task.IMultiTask<{src: string;}> = this,
-            typescriptBinPath = getTsBinPathWithLoad(),
+            typescriptBinPath = cacheBinPath || getTsBinPathWithLoad(),
             promises: Q.IPromise<any>[] = [],
             done = self.async();
+        cacheBinPath = typescriptBinPath;
+
         self.files.forEach(function (gruntFile: grunt.file.IFileMap) {
             var io: GruntTs.GruntIO = new GruntTs.GruntIO(grunt),
                 opts = new GruntTs.Opts(self.options({}),grunt, gruntFile, io);

--- a/tasks/typescript.js
+++ b/tasks/typescript.js
@@ -979,8 +979,14 @@ module.exports = function (grunt) {
         }
     };
 
+    // Used to avoid reloading the "typescript.js" file each time a compilation task processed.  Saves a
+    // considerable amount of time when there are multiple tasks.
+    var cacheBinPath;
+
     grunt.registerMultiTask('typescript', 'Compile TypeScript files', function () {
-        var self = this, typescriptBinPath = getTsBinPathWithLoad(), promises = [], done = self.async();
+        var self = this, typescriptBinPath = cacheBinPath || getTsBinPathWithLoad(), promises = [], done = self.async();
+        cacheBinPath = typescriptBinPath;
+
         self.files.forEach(function (gruntFile) {
             var io = new GruntTs.GruntIO(grunt), opts = new GruntTs.Opts(self.options({}), grunt, gruntFile, io);
 


### PR DESCRIPTION
- Saves a lot of time in a grunt task that defines a lot of subtasks (“egen” in this project is one example)
