### PR TITLE
Emit success event with compile result

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -19,11 +19,17 @@ module GruntTs{
 
         return Q.Promise((resolve: (val: any) => void, reject: (val: any) => void, notify: (val: any) => void) => {
 
+            var success: boolean;
             if(options.gWatch){
                 watch(grunt, options, host);
             }else{
                 try{
-                    if(compile(options, host)){
+                    success = compile(options, host);
+                    grunt.event.emit('grunt-typescript', {
+                        event: 'compile',
+                        success: success
+                    });
+                    if(success){
                         resolve(true);
                     }else{
                         reject(false);
@@ -50,10 +56,15 @@ module GruntTs{
             }),
             startCompile = (files?: string[]) => {
                 return runTask(grunt, host, watchOpt.before).then(() => {
-                    if(!recompile(options, host, files)){
+                    var success = recompile(options, host, files);
+                    if(!success){
                         //失敗だった場合はリセット
                         host.reset(files);
                     }
+                    grunt.event.emit('grunt-typescript', {
+                        event: 'compile',
+                        success: success
+                    });
                     return runTask(grunt, host, watchOpt.after);
                 }).then(function(){
                     writeWatching(watchPath);

--- a/tasks/typescript.js
+++ b/tasks/typescript.js
@@ -749,12 +749,18 @@ var GruntTs;
         host.io.verbose("--task.execute");
         host.io.verbose("  options: " + JSON.stringify(options));
         return Q.Promise(function (resolve, reject, notify) {
+            var success;
             if (options.gWatch) {
                 watch(grunt, options, host);
             }
             else {
                 try {
-                    if (compile(options, host)) {
+                    success = compile(options, host);
+                    grunt.event.emit('grunt-typescript', {
+                        event: 'compile',
+                        success: success
+                    });
+                    if (success) {
                         resolve(true);
                     }
                     else {
@@ -779,10 +785,15 @@ var GruntTs;
             });
         }), startCompile = function (files) {
             return runTask(grunt, host, watchOpt.before).then(function () {
-                if (!recompile(options, host, files)) {
+                var success = recompile(options, host, files);
+                if (!success) {
                     //失敗だった場合はリセット
                     host.reset(files);
                 }
+                grunt.event.emit('grunt-typescript', {
+                    event: 'compile',
+                    success: success
+                });
                 return runTask(grunt, host, watchOpt.after);
             }).then(function () {
                 writeWatching(watchPath);


### PR DESCRIPTION
Hi,

It would be great if grunt-typescript could emit an event to let us know the compilation result.

Right now with the `watch` option I don't know if the compilation result was successful or a failure unless I keep checking the console.

This pull request is a simple change to emit a "grunt-typescript" event on the `grunt` instance. Other plugins can then listen for the event and notify the developer of the result.

I got the idea from the `grunt-contrib-watch` "watch" event: https://github.com/gruntjs/grunt-contrib-watch#using-the-watch-event
