### PR TITLE
Add support for sourceRoot and mapRoot options

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ grunt.initConfig({
 | jsx                            | string  | Support JSX in '.tsx' files: 'React' or 'Preserve'.                                                                                   |
 | experimentalAsyncFunctions     | boolean | Support ES7-proposed asynchronous functions using the async/await keywords.                                                           |
 | rootDir                        | string  | Specifies the root directory of input files. Only use to control the output directory structure with outDir option.                   |
+| mapRoot                        | string  | Specifies the location where debugger should locate map files instead of generated locations.                                         |
+| sourceRoot                     | string  | Specifies the location where debugger should locate TypeScript files instead of source locations.                                     |
 
 ### original options
 

--- a/src/modules/option.ts
+++ b/src/modules/option.ts
@@ -202,12 +202,14 @@ export function createGruntOption(source: any, grunt: IGrunt, gruntFile: grunt.f
         targetVersion = prepareTarget(source),
         basePath = checkBasePath(source),
         rootDir = util.isStr(source.rootDir) ? source.rootDir : undefined,
-        keepDirectoryHierarchy = boolOrUndef(source, "keepDirectoryHierarchy");
+        keepDirectoryHierarchy = boolOrUndef(source, "keepDirectoryHierarchy"),
+        sourceRoot = util.isStr(source.sourceRoot) ? source.sourceRoot : undefined,
+        mapRoot = util.isStr(source.mapRoot) ? source.mapRoot : undefined;
 
     function getTargetFiles(): string[]{
         return <string[]>grunt.file.expand(<string[]>gruntFile.orig.src);
     }
-        
+
 
     function getReferences(): string[]{
         let target: string[],
@@ -282,7 +284,9 @@ export function createGruntOption(source: any, grunt: IGrunt, gruntFile: grunt.f
             inlineSources: boolOrUndef(source, "inlineSources"),
             noEmitHelpers: boolOrUndef(source, "noEmitHelpers"),
             jsx: prepareJsx(source),
-            experimentalAsyncFunctions: boolOrUndef(source, "experimentalAsyncFunctions")
+            experimentalAsyncFunctions: boolOrUndef(source, "experimentalAsyncFunctions"),
+            sourceRoot: sourceRoot,
+            mapRoot: mapRoot
         }
     };
 


### PR DESCRIPTION
This PR adds support for the `sourceRoot` and `mapRoot` options.

Might fix #114, #97 and #94.
