### PR TITLE
Fix broken logic in extension check

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -152,8 +152,7 @@ module.exports = function(grunt){
             "async": {
                 src: "test/fixtures/async.ts",
                 options: {
-                    target: "ES6",
-                    experimentalAsyncFunctions: true
+                    target: "ES6"
                 }
             },
             "references": {
@@ -359,7 +358,7 @@ module.exports = function(grunt){
             return execTsc("React Jsx", "test/fixtures/jsxreact.tsx --jsx react");
         }).then(function(){
             grunt.file.copy("test/fixtures/jsxreact.js", "test/expected/jsxreact.js");
-            return execTsc("Async", "test/fixtures/async.ts --experimentalAsyncFunctions -t ES6");
+            return execTsc("Async", "test/fixtures/async.ts -t ES6");
         }).then(function(){
             grunt.file.copy("test/fixtures/async.js", "test/expected/async.js");
             done(true);

--- a/package.json
+++ b/package.json
@@ -26,17 +26,17 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "typescript": "1.6.2",
+    "typescript": "1.8.10",
     "bluebird": "~2.9.34",
     "chokidar": "^1.0.5"
   },
   "peerDependencies": {
-    "grunt": "~0.4.5"
+    "grunt": "~1.0.1"
   },
   "devDependencies": {
-    "grunt": "~0.4.5",
-    "grunt-contrib-nodeunit": "~0.4.1",
-    "grunt-contrib-clean": "~0.6.0"
+    "grunt": "~1.0.1",
+    "grunt-contrib-nodeunit": "~1.0.0",
+    "grunt-contrib-clean": "~1.0.0"
   },
   "optionalDependencies": {
   },

--- a/src/modules/watcher.ts
+++ b/src/modules/watcher.ts
@@ -32,7 +32,7 @@ export function createWatcher(watchPaths: string[], callback: (targets: {[key: s
     }
 
     function add(path: string, eventName: string, stats: any){
-        if(_path.extname(path) !== ".ts" || _path.extname(path) !== ".tsx"){
+        if(_path.extname(path) !== ".ts" && _path.extname(path) !== ".tsx"){
             return;
         }
         path = util.normalizePath(path);

--- a/test/errorTest.js
+++ b/test/errorTest.js
@@ -37,7 +37,7 @@ module.exports.errorTypescript = {
         test.expect(1);
 
         exec(["typescript:errorTypecheck", "--error"], function(results){
-            test.equal(">> ".red + "test/fixtures/error-typecheck.ts(1,1): error TS2304: Cannot find name 'foo'.", trim(results[0]));
+            test.equal(">> test/fixtures/error-typecheck.ts(1,1): error TS2304: Cannot find name 'foo'.", trim(results[0]));
 
             //console.log(results[0].trim());
 
@@ -49,7 +49,7 @@ module.exports.errorTypescript = {
         "use strict";
         test.expect(1);
         exec(["typescript:errorSyntax", "--error"], function(results){
-            test.equal(">> ".red + "test/fixtures/error-syntax.ts(1,9): error TS1005: ';' expected.", trim(results[0]));
+            test.equal(">> test/fixtures/error-syntax.ts(1,9): error TS1005: ';' expected.", trim(results[0]));
             test.done();
         });
     },
@@ -60,14 +60,14 @@ module.exports.errorTypescript = {
         test.expect(8);
 
         exec(["typescript:noLib", "--error"], function(results){
-            test.equal(">> ".red + "error TS2318: Cannot find global type 'Array'.", trim(results[0]));
-            test.equal(">> ".red + "error TS2318: Cannot find global type 'Boolean'.", trim(results[1]));
-            test.equal(">> ".red + "error TS2318: Cannot find global type 'Function'.", trim(results[2]));
-            test.equal(">> ".red + "error TS2318: Cannot find global type 'IArguments'.", trim(results[3]));
-            test.equal(">> ".red + "error TS2318: Cannot find global type 'Number'.", trim(results[4]));
-            test.equal(">> ".red + "error TS2318: Cannot find global type 'Object'.", trim(results[5]));
-            test.equal(">> ".red + "error TS2318: Cannot find global type 'RegExp'.", trim(results[6]));
-            test.equal(">> ".red + "error TS2318: Cannot find global type 'String'.", trim(results[7]));
+            test.equal(">> error TS2318: Cannot find global type 'Array'.", trim(results[0]));
+            test.equal(">> error TS2318: Cannot find global type 'Boolean'.", trim(results[1]));
+            test.equal(">> error TS2318: Cannot find global type 'Function'.", trim(results[2]));
+            test.equal(">> error TS2318: Cannot find global type 'IArguments'.", trim(results[3]));
+            test.equal(">> error TS2318: Cannot find global type 'Number'.", trim(results[4]));
+            test.equal(">> error TS2318: Cannot find global type 'Object'.", trim(results[5]));
+            test.equal(">> error TS2318: Cannot find global type 'RegExp'.", trim(results[6]));
+            test.equal(">> error TS2318: Cannot find global type 'String'.", trim(results[7]));
             test.done();
         });
     },
@@ -78,7 +78,7 @@ module.exports.errorTypescript = {
         test.expect(1);
 
         exec(["typescript:noLibCore", "--error"], function(results){
-            test.equal(">> ".red + "test/fixtures/noLib.ts(4,10): error TS2304: Cannot find name 'document'.", trim(results[0]));
+            test.equal(">> test/fixtures/noLib.ts(4,10): error TS2304: Cannot find name 'document'.", trim(results[0]));
 
             test.done();
         });


### PR DESCRIPTION
The extension will always be either !== ".ts" or !== ".tsx". The check was meant to allow .ts and .tsx through, so should return when the ext !== ".ts" and !== ".tsx".
